### PR TITLE
Fix things in getPixel function

### DIFF
--- a/PNG.js
+++ b/PNG.js
@@ -138,9 +138,11 @@ PNG.prototype.getPalette = function(){
  */
 PNG.prototype.getPixel = function(x, y){
 	if (!this.pixels) throw new Error("pixel data is empty");
-	if (x >= this.width || y >= this.height){
+	if (x > this.width || y > this.height){
 		throw new Error("x,y position out of bound");
 	}
+	x = Math.round(x);
+	y = Math.round(y);
 	var i = this.colors * this.bitDepth / 8 * (y * this.width + x);
 	var pixels = this.pixels;
 


### PR DESCRIPTION
Allow arguments of getPixel() equal to bound and ensure that arguments x & y are rounded
