### PR TITLE
Adds a getRGBA8Array method

### DIFF
--- a/PNG.js
+++ b/PNG.js
@@ -157,4 +157,23 @@ PNG.prototype.getPixel = function(x, y){
 	}
 };
 
+/**
+ * get the pixels of the image as a RGBA array of the form [r1, g1, b1, a1, r2, b2, g2, a2, ...]
+ * Matches the api of canvas.getImageData
+ */
+PNG.prototype.getRGBA8Array = function(){
+	var data = new Array(this.width * this.height * 4);
+	for (var y = 0; y < this.height; y++) {
+		for (var x = 0; x < this.width; x++) {
+			var pixelData = this.getPixel(x, y);
+
+			data[(y * this.width + x) * 4 + 0] = pixelData[0];
+			data[(y * this.width + x) * 4 + 1] = pixelData[1];
+			data[(y * this.width + x) * 4 + 2] = pixelData[2];
+			data[(y * this.width + x) * 4 + 3] = pixelData[3];
+		}
+	}
+	return data;
+};
+
 module.exports = PNG;

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ from the image.
 png.getWidth();
 png.getHeight();
 png.getPixel(x, y); // [red, blue, green, alpha]
+png.getRGBA8Array(); // [r1, g1, b1, a1, r2, b2, g2, a2, ... ] - Same as canvas.getImageData
 // but also
 png.getBitDepth();
 png.getColorType();


### PR DESCRIPTION
This PR adds a method to get the pixel data as an RGBA array. This matches the api of `canvas.getImageData`, which many image reading libraries implement. 

- https://www.npmjs.com/package/pngjs#property-data
- https://www.npmjs.com/package/upng-js#upngtorgba8img
- https://www.npmjs.com/package/jpeg-js#decoding-jpegs
etc. 

Having this functionality in the library would save consumers the pain of re-implimenting this behavior if they need to pass the image data to something (like `canvas.putImageData`) which uses this common data structure. 

This change is pretty straightforward, but happy to make any changes/answer questions etc. 