### PR TITLE
Changed Buffer() to Buffer.from() because Buffer() constructor is deprecated.

### DIFF
--- a/PNGReader.js
+++ b/PNGReader.js
@@ -5,7 +5,7 @@ var zlib = require('zlib');
 var PNG = require('./PNG');
 
 var inflate = function(data, callback){
-	return zlib.inflate(new Buffer(data), callback);
+	return zlib.inflate(Buffer.from(data), callback);
 };
 
 var slice = Array.prototype.slice;
@@ -188,12 +188,12 @@ PNGReader.prototype.decodePixels = function(callback){
 	var length = 0;
 	var i, j, k, l;
 	for (l = this.dataChunks.length; l--;) length += this.dataChunks[l].length;
-	var data = new Buffer(length);
+	var data = new Array(length);
 	for (i = 0, k = 0, l = this.dataChunks.length; i < l; i++){
 		var chunk = this.dataChunks[i];
 		for (j = 0; j < chunk.length; j++) data[k++] = chunk[j];
 	}
-	inflate(data, function(err, data){
+	inflate(Buffer.from(data), function(err, data){
 		if (err) return callback(err);
 
 		try {
@@ -222,7 +222,7 @@ PNGReader.prototype.interlaceNone = function(data){
 	// color bytes per row
 	var cpr = bpp * png.width;
 
-	var pixels = new Buffer(bpp * png.width * png.height);
+	var pixels = new Array(bpp * png.width * png.height);
 	var scanline;
 	var offset = 0;
 
@@ -243,7 +243,7 @@ PNGReader.prototype.interlaceNone = function(data){
 
 	}
 
-	png.pixels = pixels;
+	png.pixels = Buffer.from(pixels);
 
 };
 


### PR DESCRIPTION
Referring to this warning: 
> [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

I have changed the Buffer() to Buffer.from(). Also, i have checked it and library is working fine as before.