### PR TITLE
adding decoders for text metadata (iTXt, tEXt and zTXt)

### DIFF
--- a/PNG.js
+++ b/PNG.js
@@ -18,6 +18,7 @@ var PNG = function(){
 	this.palette = null;
 	this.pixels = null;
 	this.trns = null;
+	this.text = {};
 
 };
 


### PR DESCRIPTION
I would like to be able to access the text metadata from PNG files in the browser, and this patch adds decoders for the three "Textual Information" chunk types as defined in https://www.w3.org/TR/2003/REC-PNG-20031110/#11.3.4
The resulting values are stored in the png object under the property png.text, which is initialized to an empty object {}